### PR TITLE
fix: apply orientation metadata to image uploads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -376,6 +376,7 @@ dependencies = [
  "futures",
  "image",
  "imagesize",
+ "kamadak-exif",
  "lazy_static",
  "log",
  "mime",
@@ -1356,6 +1357,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "kamadak-exif"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70494964492bf8e491eb3951c5d70c9627eb7100ede6cc56d748b9a3f302cfb6"
+dependencies = [
+ "mutate_once",
+]
+
+[[package]]
 name = "language-tags"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1618,6 +1628,12 @@ dependencies = [
  "webpki",
  "webpki-roots",
 ]
+
+[[package]]
+name = "mutate_once"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16cf681a23b4d0a43fc35024c176437f9dcd818db34e0f42ab456a0ee5ad497b"
 
 [[package]]
 name = "nanoid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ env_logger = "0.7.1"
 tree_magic = "0.2.3"
 serde_json = "1.0.60"
 lazy_static = "1.4.0"
+kamadak-exif = "0.5.4"
 sanitize-filename = "0.3.0"
 content_inspector = "0.2.4"
 serde = { version = "1.0.118", features = ["derive"] }


### PR DESCRIPTION
## Please make sure to check the following tasks before opening and submitting a PR

* [x] I understand and have followed the [contribution guide](https://github.com/revoltchat/revolt/discussions/282)
* [x] I have tested my changes locally and they are working as intended
* [x] These changes do not have any notable side effects on other Revolt projects

Fixes #20.

This PR adds `kamadak-exif` as a dependency to read EXIF metadata from uploaded image files.

For testing, here are 8 variants of the same image file created by an iPhone, with manipulated orientation metadata: [exif_test.zip](https://github.com/revoltchat/autumn/files/8654866/exif_test.zip).