### PR TITLE
fix: calculate image dimensions after rotation

### DIFF
--- a/src/routes/upload.rs
+++ b/src/routes/upload.rs
@@ -121,11 +121,23 @@ pub async fn post(req: HttpRequest, mut payload: Multipart) -> Result<HttpRespon
                             .map_err(|_| Error::IOError)?;
 
                         buf = bytes;
-                    }
+  
+                        // Calculate dimensions after rotation.
+                        let (width, height) = match &rotation {
+                            2 | 4 | 5 | 7 => (height, width),
+                            _ => (width, height)
+                        };
 
-                    Metadata::Image {
-                        width: width.try_into().map_err(|_| Error::IOError)?,
-                        height: height.try_into().map_err(|_| Error::IOError)?
+                        Metadata::Image {
+                            width: width.try_into().map_err(|_| Error::IOError)?,
+                            height: height.try_into().map_err(|_| Error::IOError)?
+                        }
+                    } else {
+                        // GIFs and WebPs will not be re-encoded.
+                        Metadata::Image {
+                            width: width.try_into().map_err(|_| Error::IOError)?,
+                            height: height.try_into().map_err(|_| Error::IOError)?
+                        }
                     }
                 } else {
                     Metadata::File


### PR DESCRIPTION
autumn previously returned image size metadata that did not factor in the rotation, which caused mild problems for API consumers that depend on those values to build a layout

## Please make sure to check the following tasks before opening and submitting a PR

* [X] I understand and have followed the [contribution guide](https://github.com/revoltchat/revolt/discussions/282)
* [X] I have tested my changes locally and they are working as intended
* [X] These changes do not have any notable side effects on other Revolt projects
