### PR TITLE
feat: add s3 bucket prefix config option

### DIFF
--- a/src/util/variables.rs
+++ b/src/util/variables.rs
@@ -23,6 +23,7 @@ lazy_static! {
         region: env::var("AUTUMN_S3_REGION").unwrap_or_else(|_| "".to_string()),
         endpoint: env::var("AUTUMN_S3_ENDPOINT").unwrap_or_else(|_| "".to_string())
     };
+    pub static ref S3_BUCKET_PREFIX: String = env::var("AUTUMN_S3_BUCKET_PREFIX").unwrap_or_else(|_| "".to_string());
     pub static ref S3_CREDENTIALS: Credentials = Credentials::default().unwrap();
 
     // Application Flags
@@ -30,6 +31,12 @@ lazy_static! {
 }
 
 pub fn get_s3_bucket(bucket: &str) -> Result<s3::Bucket, Error> {
-    s3::Bucket::new_with_path_style(bucket, S3_REGION.clone(), S3_CREDENTIALS.clone())
-        .map_err(|_| Error::S3Error)
+    let mut final_bucket_path = S3_BUCKET_PREFIX.to_owned();
+    final_bucket_path.push_str(bucket);
+    s3::Bucket::new_with_path_style(
+        &final_bucket_path,
+        S3_REGION.clone(),
+        S3_CREDENTIALS.clone(),
+    )
+    .map_err(|_| Error::S3Error)
 }


### PR DESCRIPTION
Closes #11 

This PR adds the ability to add `AUTUMN_S3_BUCKET_PREFIX` as an environment variable, to allow for autumn to fetch the bucket based on a prefix.

This is done since S3 Buckets needs to be [globally unique](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html) _second to last naming rule_ 

## Please make sure to check the following tasks before opening and submitting a PR

* [x] I understand and have followed the [contribution guide](https://github.com/revoltchat/revolt/discussions/282)
* [x] I have tested my changes locally and they are working as intended
* [x] These changes do not have any notable side effects on other Revolt projects
